### PR TITLE
Update to work with Keycloak 22

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ on:
       - main
 
 jobs:
-  target_node:
+  build:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository code.
@@ -19,6 +19,12 @@ jobs:
         with:
           distribution: 'zulu'
           java-version: '17'
-      - name: Build a shaded fat jar.
+      - name: Build a shaded fat jar for Twilio integration.
         working-directory: twilio-keycloak-provider
         run: ../gradlew shadowJar
+      - name: Build the RequiredAction jar.
+        working-directory: keycloak-required-action
+        run: ../gradlew jar
+      - name: Build the Keycloak theme jar.
+        working-directory: pdc-keycloak-theme
+        run: ../gradlew jar

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ on:
       - main
 
 jobs:
-  target_node:
+  test:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository code.

--- a/keycloak-required-action/build.gradle.kts
+++ b/keycloak-required-action/build.gradle.kts
@@ -13,9 +13,10 @@ java {
   }
 }
 
-// We target the class version of the JRE used in the keycloak container: 11.
+
+// We target the version of the JRE currently used by Keycloak: 17.
 tasks.compileJava {
-  options.release.set(11)
+  options.release.set(17)
 }
 
 repositories {
@@ -23,7 +24,7 @@ repositories {
 }
 
 ext {
-  set("keycloakVersion", "20.0.5")
+  set("keycloakVersion", "22.0.1")
 }
 
 dependencies {

--- a/keycloak-required-action/src/main/java/org/philanthropydatacommons/keycloak/requiredaction/MobileNumberRequiredAction.java
+++ b/keycloak-required-action/src/main/java/org/philanthropydatacommons/keycloak/requiredaction/MobileNumberRequiredAction.java
@@ -4,6 +4,9 @@
  */
 package org.philanthropydatacommons.keycloak.requiredaction;
 
+import jakarta.ws.rs.core.MultivaluedMap;
+import jakarta.ws.rs.core.Response;
+
 import org.keycloak.authentication.InitiatedActionSupport;
 import org.keycloak.authentication.RequiredActionContext;
 import org.keycloak.authentication.RequiredActionProvider;
@@ -12,8 +15,6 @@ import org.keycloak.models.UserModel;
 import org.keycloak.models.utils.FormMessage;
 import org.keycloak.services.validation.Validation;
 
-import javax.ws.rs.core.MultivaluedMap;
-import javax.ws.rs.core.Response;
 import java.util.function.Consumer;
 
 /**

--- a/twilio-keycloak-provider/build.gradle.kts
+++ b/twilio-keycloak-provider/build.gradle.kts
@@ -11,7 +11,7 @@ plugins {
     // keycloak classpath with a single jar. The alternative would be to copy/include each jar
     // and dependent jars onto the keycloak classpath. See exclusions below because there is some
     // overlap in the twilio and keycloak dependencies.
-    id("com.github.johnrengelman.shadow") version "7.1.2"
+    id("com.github.johnrengelman.shadow") version "8.1.1"
 }
 
 // We expect the current LTS version of the JDK for IDEs, compilation, etc.: 17.
@@ -42,17 +42,17 @@ dependencies {
     compileOnly("org.keycloak:keycloak-server-spi:${project.ext.get("keycloakVersion")}")
     compileOnly("org.keycloak:keycloak-server-spi-private:${project.ext.get("keycloakVersion")}")
     compileOnly("org.keycloak:keycloak-services:${project.ext.get("keycloakVersion")}")
-    compileOnly("com.github.dasniko:keycloak-spi-bom:20.0.0")
+    compileOnly("com.github.dasniko:keycloak-spi-bom:22.0.0")
     // Twilio's dependencies are used by our extension but not intended to be further exposed.
     // The shadow plugin jar (shadowJar task) will include this and its dependencies.
-    implementation("com.twilio.sdk:twilio:9.2.3")
+    implementation("com.twilio.sdk:twilio:9.12.0")
 
     // Use JUnit Jupiter for testing.
-    testImplementation("org.junit.jupiter:junit-jupiter:5.9.1")
+    testImplementation("org.junit.jupiter:junit-jupiter:5.10.0")
     // In keycloak, slf4j is bridged to jboss-logging. For test runtime here use slf4j-simple.
-    testImplementation("org.slf4j:slf4j-simple:2.0.6")
+    testImplementation("org.slf4j:slf4j-simple:2.0.9")
     // To create mock instances
-    testImplementation("org.mockito:mockito-junit-jupiter:5.1.1")
+    testImplementation("org.mockito:mockito-junit-jupiter:5.5.0")
     testImplementation("org.keycloak:keycloak-core:${project.ext.get("keycloakVersion")}")
     testImplementation("org.keycloak:keycloak-server-spi-private:${project.ext.get("keycloakVersion")}")
     testImplementation("org.keycloak:keycloak-server-spi:${project.ext.get("keycloakVersion")}")

--- a/twilio-keycloak-provider/build.gradle.kts
+++ b/twilio-keycloak-provider/build.gradle.kts
@@ -21,9 +21,9 @@ java {
     }
 }
 
-// We target the version of the JRE used in the keycloak container: 11.
+// We target the version of the JRE currently used by Keycloak: 17.
 tasks.compileJava {
-    options.release.set(11)
+    options.release.set(17)
 }
 
 repositories {
@@ -31,7 +31,7 @@ repositories {
 }
 
 ext {
-    set("keycloakVersion", "20.0.5");
+    set("keycloakVersion", "22.0.1");
 }
 
 dependencies {

--- a/twilio-keycloak-provider/src/main/java/org/philanthropydatacommons/auth/twilio/authenticator/SmsAuthenticator.java
+++ b/twilio-keycloak-provider/src/main/java/org/philanthropydatacommons/auth/twilio/authenticator/SmsAuthenticator.java
@@ -5,6 +5,7 @@
  */
 package org.philanthropydatacommons.auth.twilio.authenticator;
 
+import jakarta.ws.rs.core.Response;
 import org.keycloak.authentication.AuthenticationFlowContext;
 import org.keycloak.authentication.AuthenticationFlowError;
 import org.keycloak.authentication.Authenticator;
@@ -20,7 +21,6 @@ import org.philanthropydatacommons.auth.twilio.SmsSender;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.ws.rs.core.Response;
 import java.io.IOException;
 import java.security.MessageDigest;
 import java.time.*;


### PR DESCRIPTION
Keycloak now uses Java 17 and the re-namespaced JAX-RS dependencies.
Update imports and libraries such that methods are found by Keycloak.

Issue https://github.com/PhilanthropyDataCommons/auth/issues/27 Compile libraries against recent Keycloak