### PR TITLE
Print failures from test reports

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,4 +21,4 @@ jobs:
           java-version: '17'
       - name: Run tests and code coverage report.
         working-directory: twilio-keycloak-provider
-        run: ../gradlew test jacocoReport
+        run: ../gradlew test jacocoReport || grep -A 100 -i failed build/reports/tests/test/classes/*html


### PR DESCRIPTION
In order to show the exceptions in (hopefully) all cases, this commit simply prints 100+ lines of relevant sections of HTML to the console. For `TestEngine with ID 'junit-jupiter' failed to discover tests` this should be sufficient.

Many online posts suggestions to configure the `testLogging` block do not result in displaying an exception when Jupiter fails at running a test. It is also surprising to find no `stdout` or `stderr` report options out of the box. I guess when Gradle and Jupiter were coming of age, Jenkins was the CI/CD system de jour and made it trivial to see these reports.

Issue #48: Show test failure output in job