### PR TITLE
Upgrade JUnit/Jupiter dependencies together

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,11 @@ updates:
       - 'keycloak-required-action'
     schedule:
       interval: 'daily'
+    groups:
+      junit-jupiter:
+        patterns:
+          - 'org.junit.*'
+          - 'org.mockito.*jupiter*'
   - package-ecosystem: 'github-actions'
     directory: '.github/workflows'
     schedule:

--- a/twilio-keycloak-provider/build.gradle.kts
+++ b/twilio-keycloak-provider/build.gradle.kts
@@ -48,11 +48,13 @@ dependencies {
     implementation("com.twilio.sdk:twilio:9.12.0")
 
     // Use JUnit Jupiter for testing.
-    testImplementation("org.junit.jupiter:junit-jupiter:5.10.0")
+    testRuntimeOnly("org.junit.platform:junit-platform-engine:1.13.0")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher:1.13.0")
+    testImplementation("org.junit.jupiter:junit-jupiter:5.13.0")
     // In keycloak, slf4j is bridged to jboss-logging. For test runtime here use slf4j-simple.
     testImplementation("org.slf4j:slf4j-simple:2.0.17")
     // To create mock instances
-    testImplementation("org.mockito:mockito-junit-jupiter:5.5.0")
+    testImplementation("org.mockito:mockito-junit-jupiter:5.18.0")
     testImplementation("org.keycloak:keycloak-core:${project.ext.get("keycloakVersion")}")
     testImplementation("org.keycloak:keycloak-server-spi-private:${project.ext.get("keycloakVersion")}")
     testImplementation("org.keycloak:keycloak-server-spi:${project.ext.get("keycloakVersion")}")


### PR DESCRIPTION
To get started, update test dependencies manually along with new required Jupiter `testRuntimeOnly` dependencies. More importantly, tell Dependabot to group these dependencies in future.

Related to pull request #43 that failed with a Jupiter upgrade.