### PR TITLE
Shade newly included-in-Twilio libraries

### DIFF
--- a/twilio-keycloak-provider/build.gradle.kts
+++ b/twilio-keycloak-provider/build.gradle.kts
@@ -102,6 +102,9 @@ tasks.shadowJar {
     relocate("com.twilio", "org.philanthropydatacommons.shadow.com.twilio")
     relocate("org.json", "org.philanthropydatacommons.shadow.org.json")
     relocate("io.jsonwebtoken", "org.philanthropydatacommons.shadow.io.jsonwebtoken")
+    relocate("org.apache.hc.core5", "org.philanthropydatacommons.shadow.org.apache.hc.core5")
+    relocate("org.apache.hc.client5", "org.philanthropydatacommons.shadow.org.apache.hc.client5")
+    relocate("org.publicsuffix", "org.philanthropydatacommons.shadow.org.publicsuffix")
 
     // The mergeServiceFiles also relocates the SPI definitions in META-INF/services
     mergeServiceFiles()


### PR DESCRIPTION
This avoids classpath conflicts when this jar is included in Keycloak. Keycloak 26 appears to use HttpClient 4 while Twilio's library 11 uses HttpClient 5. Include `org.publicsuffix` in case it is used.

Fixes #81 Twilio provider shaded jar is larger than expected