### PR TITLE
Add workflow to auto-add issues to project

### DIFF
--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -1,0 +1,11 @@
+name: Add to project
+
+on:
+  issues:
+    types: [opened, transferred, reopened]
+
+jobs:
+  add-to-project:
+    uses: PhilanthropyDataCommons/.github/.github/workflows/add-to-project.yml@v1
+    secrets:
+      PDC_BOT_PRIVATE_KEY: ${{ secrets.PDC_BOT_PRIVATE_KEY }}


### PR DESCRIPTION
Adds a caller workflow so new issues in this repository are automatically added to the organization project board, via the shared reusable workflow in `PhilanthropyDataCommons/.github`.

**Depends on** these being in place before it will do anything:
- `PhilanthropyDataCommons/.github#5` reusable workflow merged to `main`
- `pdc-bot` GitHub App created and the org `PDC_BOT_APP_ID` / `PDC_BOT_PRIVATE_KEY` / `ADD_TO_PROJECT_URL` secrets/variables configured

Until then this is inert (it triggers only on `issues` events, not on this PR), so it is safe to merge in any order.

Issue: PhilanthropyDataCommons/.github#5

🤖 Generated with [Claude Code](https://claude.com/claude-code)
