### PR TITLE
Upgrade Gradle and OpenJDK

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/setup-java@v5
         with:
           distribution: 'zulu'
-          java-version: '17'
+          java-version: '25'
       - name: Build a shaded fat jar for Twilio integration.
         working-directory: twilio-keycloak-provider
         run: ../gradlew shadowJar

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/setup-java@v5
         with:
           distribution: 'zulu'
-          java-version: '17'
+          java-version: '25'
       - name: Run tests and code coverage report.
         working-directory: twilio-keycloak-provider
         run: ../gradlew test jacocoReport || grep -A 100 -i failed build/reports/tests/test/classes/*html

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.6.1-bin.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/keycloak-required-action/build.gradle.kts
+++ b/keycloak-required-action/build.gradle.kts
@@ -9,7 +9,7 @@ plugins {
 // We expect the current LTS version of the JDK for IDEs, compilation, etc.: 17.
 java {
   toolchain {
-    languageVersion.set(JavaLanguageVersion.of(17))
+    languageVersion.set(JavaLanguageVersion.of(25))
   }
 }
 
@@ -24,7 +24,7 @@ repositories {
 }
 
 ext {
-  set("keycloakVersion", "22.0.1")
+  set("keycloakVersion", "26.6.4")
 }
 
 dependencies {

--- a/pdc-keycloak-theme/build.gradle.kts
+++ b/pdc-keycloak-theme/build.gradle.kts
@@ -6,16 +6,16 @@ plugins {
     `java-library`
 }
 
-// We expect the current LTS version of the JDK for IDEs, compilation, etc.: 17.
+// We expect the current LTS version of the JDK for IDEs, compilation, etc.: 25.
 java {
     toolchain {
-        languageVersion.set(JavaLanguageVersion.of(17))
+        languageVersion.set(JavaLanguageVersion.of(25))
     }
 }
 
 // We target the class version of the JRE used in the keycloak container: 11.
 tasks.compileJava {
-    options.release.set(11)
+    options.release.set(17)
 }
 
 repositories {

--- a/twilio-keycloak-provider/build.gradle.kts
+++ b/twilio-keycloak-provider/build.gradle.kts
@@ -14,10 +14,10 @@ plugins {
     id("com.gradleup.shadow") version "9.2.2"
 }
 
-// We expect the current LTS version of the JDK for IDEs, compilation, etc.: 17.
+// We expect the current LTS version of the JDK for IDEs, compilation, etc.: 25.
 java {
     toolchain {
-        languageVersion.set(JavaLanguageVersion.of(17))
+        languageVersion.set(JavaLanguageVersion.of(25))
     }
 }
 
@@ -31,7 +31,7 @@ repositories {
 }
 
 ext {
-    set("keycloakVersion", "26.2.5");
+    set("keycloakVersion", "26.6.4");
 }
 
 dependencies {


### PR DESCRIPTION
Use a recent Gradle version (9.6.1) and current OpenJDK LTS (25).