### PR TITLE
Add pdc-keycloak-theme-notice login theme for maintenance banners

### DIFF
--- a/pdc-keycloak-theme/README.md
+++ b/pdc-keycloak-theme/README.md
@@ -49,6 +49,57 @@ If you are changing authentication workflows, start in your development environm
 
 Font assets, including font-specific CSS, are added to the jar during the build via the `unpackSourceSansPro` task on which the `jar` task depends. There is no need to explicitly run this task but if you change the `unpackSourceSansPro` task code you may need to `../gradlew clean jar` to get up-to-date results.
 
+## Maintenance notice theme (pdc-keycloak-theme-notice)
+
+This jar also ships a second, thin login theme called `pdc-keycloak-theme-notice`
+that extends `pdc-keycloak-theme` and adds a maintenance/upgrade notice banner to
+the bottom of every login page. It uses the Custom Footer hook introduced in
+Keycloak 26.0.0, so it does not override `template.ftl` and is safe across
+Keycloak upgrades.
+
+### How to show the notice
+
+1. Build and deploy this jar (see above) so both themes are on the classpath.
+2. In the Admin Console, go to **Realm Settings → Themes → Login Theme** and
+   select **`pdc-keycloak-theme-notice`**, then **Save**.
+
+The notice appears immediately — no restart is needed to switch themes.
+
+### How to hide the notice
+
+Switch the Login Theme back to **`pdc-keycloak-theme`** and **Save**. No restart
+and no file changes are required.
+
+### How to change the notice text (no file edits, no restart)
+
+The notice text is the message key `maintenanceNotice` (with a default in
+`theme/pdc-keycloak-theme-notice/login/messages/messages_en.properties`). The
+default is intentionally **generic and placeholder-free** ("Scheduled maintenance
+may briefly interrupt access to this service...") so that if the notice theme
+is enabled before the text is customized, users see a sensible message rather
+than something like "YYYY-MM-DD between HH:MM and HH:MM".
+
+To set the actual maintenance window at runtime:
+
+1. Go to **Realm Settings → Localization**.
+2. Enable internationalization if it isn't already (you can keep `en` as the
+   only supported locale — users won't see anything different).
+3. Open the **Realm Overrides** tab.
+4. Add/edit the key `maintenanceNotice` for locale `en` and set your text.
+5. Save.
+
+Realm Overrides are stored in the database and take effect immediately. The
+value may contain a safe subset of HTML (passed through Keycloak's `kcSanitize`):
+`<strong>`, `<a href>`, `<br>`, `<p>`, `<em>`, `<b>`, `<ul>/<li>`, etc.
+
+Example override (replace the placeholders with your actual window):
+
+```
+<strong>Upgrade notice:</strong> Keycloak will be unavailable on
+<strong>YYYY-MM-DD</strong> from <strong>HH:MM</strong> to <strong>HH:MM</strong> UTC.
+See <a href="https://status.example.com/">status.example.com</a> for details.
+```
+
 ## License
 
 Apache License 2.0, see the LICENSE file.

--- a/pdc-keycloak-theme/src/main/resources/META-INF/keycloak-themes.json
+++ b/pdc-keycloak-theme/src/main/resources/META-INF/keycloak-themes.json
@@ -2,5 +2,8 @@
     "themes": [{
         "name" : "pdc-keycloak-theme",
         "types": [ "account", "admin", "common", "email", "login" ]
+    }, {
+        "name" : "pdc-keycloak-theme-notice",
+        "types": [ "login" ]
     }]
 }

--- a/pdc-keycloak-theme/src/main/resources/theme/pdc-keycloak-theme-notice/login/footer.ftl
+++ b/pdc-keycloak-theme/src/main/resources/theme/pdc-keycloak-theme-notice/login/footer.ftl
@@ -1,0 +1,35 @@
+<#--
+  Maintenance / upgrade notice shown at the bottom of every
+  login page.
+
+  The text is read from the "maintenanceNotice" message key so it
+  can be changed from the Admin Console (Realm Settings ->
+  Localization -> Realm Overrides) WITHOUT editing this file or
+  restarting the server.
+
+  The value may contain a safe subset of HTML: it is passed through
+  Keycloak's kcSanitize, so tags like <strong>, <a href>, <br>, <p>,
+  <em> are allowed (see KeycloakSanitizerPolicy). This is the same
+  mechanism the built-in "Terms and Conditions" page uses for its
+  termsText.
+
+  Styling uses the theme's own PatternFly v4 alert classes (inherited
+  from keycloak v1 via pdc-keycloak-theme), so the notice matches the
+  rest of the login UI. The pf-c-alert__icon class is hardcoded
+  here to match the base v1 template.ftl convention
+  (kcAlertIconClass is only defined in v2+).
+
+  To hide the notice, switch the realm's Login Theme back to
+  "pdc-keycloak-theme" in the Admin Console (no restart required).
+-->
+<#macro content>
+  <div class="${properties.kcAlertClass!} pf-m-warning"
+       style="margin-top: 1rem;" role="status">
+    <div class="pf-c-alert__icon">
+      <span class="${properties.kcFeedbackWarningIcon!}"
+            aria-hidden="true"></span>
+    </div>
+    <span class="${properties.kcAlertTitleClass!}"
+      >${kcSanitize(msg("maintenanceNotice"))?no_esc}</span>
+  </div>
+</#macro>

--- a/pdc-keycloak-theme/src/main/resources/theme/pdc-keycloak-theme-notice/login/messages/messages_en.properties
+++ b/pdc-keycloak-theme/src/main/resources/theme/pdc-keycloak-theme-notice/login/messages/messages_en.properties
@@ -1,0 +1,20 @@
+# Default text for the maintenance/upgrade notice shown in the login
+# footer.
+#
+# This is intentionally generic and has NO placeholders, so if the
+# notice theme is enabled before the text is customized, users see a
+# sensible message rather than something like
+# "YYYY-MM-DD between HH:MM and HH:MM".
+#
+# To set the actual maintenance window (no file edits, no restart),
+# override this key from the Admin Console:
+#     Realm Settings -> Localization -> Realm Overrides
+#         Locale: en   Key: maintenanceNotice   Value: <your text>
+# (Realm Overrides require internationalization to be enabled for the
+#  realm; with "en" as the only supported locale it is transparent to
+#  users.)
+#
+# A safe subset of HTML is allowed (kcSanitize): <strong>, <a href>,
+# <br>, <p>, <em>, <b>, <ul>/<li>, etc.
+
+maintenanceNotice = <strong>Notice:</strong> Scheduled maintenance may briefly interrupt access to this service.

--- a/pdc-keycloak-theme/src/main/resources/theme/pdc-keycloak-theme-notice/login/theme.properties
+++ b/pdc-keycloak-theme/src/main/resources/theme/pdc-keycloak-theme-notice/login/theme.properties
@@ -1,0 +1,28 @@
+# pdc-keycloak-theme-notice
+#
+# A thin login theme that extends pdc-keycloak-theme and adds a
+# maintenance/upgrade notice to the bottom of every login page via the
+# Custom Footer hook introduced in Keycloak 26.0.0
+# (see base/login/footer.ftl).
+#
+# It does NOT override template.ftl, so it survives Keycloak upgrades
+# cleanly. Only footer.ftl and the "maintenanceNotice" message key are
+# contributed here; everything else (CSS, layout, templates, message
+# bundles) is inherited from pdc-keycloak-theme -> keycloak -> base.
+#
+# To turn the notice on:
+#   Realm Settings -> Themes -> Login Theme ->
+#   pdc-keycloak-theme-notice
+# To turn the notice off:
+#   Realm Settings -> Themes -> Login Theme ->
+#   pdc-keycloak-theme
+
+# Extend the existing PDC login theme (which itself extends
+# keycloak v1).
+parent=pdc-keycloak-theme
+
+# Import the PDC common resources (fonts, CSS). These match the
+# parent's convention so the notice is styled consistently with the
+# login UI.
+import=common/pdc-keycloak-theme
+common=common/pdc-keycloak-theme


### PR DESCRIPTION
## Summary

Adds a second, thin login theme (`pdc-keycloak-theme-notice`) to the `pdc-keycloak-theme` jar. It extends the existing `pdc-keycloak-theme` and renders a maintenance/upgrade notice banner at the bottom of every login page via the Custom Footer hook introduced in Keycloak 26.0.0.

## Motivation

When upgrading Keycloak, we want to provide an in-band notice to users who log in, informing them that an upgrade or maintenance window is scheduled. This theme provides a non-blocking banner (users can still sign in normally) that can be toggled on/off and edited from the Admin Console without a rebuild or restart.

## Changes

- **New theme `pdc-keycloak-theme-notice`** (\`login\` type only):
  - \`theme.properties\` — extends \`pdc-keycloak-theme\` (inherits all existing styling, templates, CSS, fonts)
  - \`footer.ftl\` — overrides only the Custom Footer hook (not \`template.ftl\`), rendering a PatternFly v4 warning alert with the \`maintenanceNotice\` message key
  - \`messages/messages_en.properties\` — generic, placeholder-free default for \`maintenanceNotice\`
- **\`META-INF/keycloak-themes.json\`** — registered the new theme so \`ClasspathThemeProviderFactory\` discovers it
- **\`README.md\`** — documented how to show/hide the notice and change its text

## How it works

- The notice uses the Custom Footer hook (\`<#macro content>\` in \`footer.ftl\`), introduced in Keycloak 26.0.0. Because it does **not** fork \`template.ftl\`, it is safe across Keycloak upgrades — upstream layout changes are inherited automatically.
- The alert uses PatternFly v4 classes (\`pf-c-alert__icon\`) inherited from the existing \`keycloak\` v1 parent theme, so it matches the rest of the login UI.
- The notice text is the message key \`maintenanceNotice\` with a generic, placeholder-free default. The actual maintenance window can be set at runtime via **Realm Settings → Localization → Realm Overrides** (no file edits, no restart).

## Usage

1. Deploy the rebuilt jar to Keycloak's \`/providers\` directory.
2. **Admin Console → Realm Settings → Themes → Login Theme → \`pdc-keycloak-theme-notice\` → Save** to show the notice.
3. To hide: switch Login Theme back to \`pdc-keycloak-theme\` → Save.
4. To customize text: Realm Settings → Localization → Realm Overrides → key \`maintenanceNotice\`.

## Testing

- \`../gradlew jar\` — builds successfully (jar contains both themes, verified via \`jar tf\` and \`unzip -p\`).
- \`../gradlew test jacocoReport\` — all tests pass (twilio-keycloak-provider: 2 test suites, 0 failures, 0 errors).
